### PR TITLE
Use Tilt for rendering ERB views

### DIFF
--- a/hyperloop.gemspec
+++ b/hyperloop.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "nokogiri", "~> 1.6.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-debugger"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14"
 end

--- a/hyperloop.gemspec
+++ b/hyperloop.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rack', '~> 1.5'
+  spec.add_dependency 'tilt', '~> 1.4.1'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "nokogiri", "~> 1.6.0"

--- a/hyperloop.gemspec
+++ b/hyperloop.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "nokogiri", "~> 1.6.0"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 2.14"
 end

--- a/lib/hyperloop/view.rb
+++ b/lib/hyperloop/view.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'tilt'
 
 module Hyperloop
   class View
@@ -31,18 +32,15 @@ module Hyperloop
       when :html
         @data
       when :erb
+        view_html = Tilt['erb'].new { @data }.render
+
         if @layout_data
-          render_in_layout { @data }
+          layout_template = Tilt['erb'].new { @layout_data }
+          layout_template.render { view_html }
         else
-          ERB.new(@data).result
+          view_html
         end
       end
-    end
-
-    private
-
-    def render_in_layout
-      ERB.new(@layout_data).result(binding)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'nokogiri'
+require 'pry'
+
 require 'hyperloop'
 
 module Helpers


### PR DESCRIPTION
This branch adds Tilt and uses it for rendering ERB views instead of using ERB directly. This is primarily because doing layouts with `yield` is very weird in regular ERB, and Tilt does it in a much saner way. In the future, we might also use Tilt for Sass stuff.

This also brings Pry in cuz it's cool.
