### PR TITLE
Get partials working

### DIFF
--- a/lib/hyperloop.rb
+++ b/lib/hyperloop.rb
@@ -2,6 +2,7 @@ require "hyperloop/application"
 require "hyperloop/response"
 require "hyperloop/version"
 require "hyperloop/view"
+require "hyperloop/view/registry"
 require "hyperloop/view/scope"
 
 module Hyperloop

--- a/lib/hyperloop.rb
+++ b/lib/hyperloop.rb
@@ -2,6 +2,7 @@ require "hyperloop/application"
 require "hyperloop/response"
 require "hyperloop/version"
 require "hyperloop/view"
+require "hyperloop/view/scope"
 
 module Hyperloop
   # Your code goes here...

--- a/lib/hyperloop.rb
+++ b/lib/hyperloop.rb
@@ -6,5 +6,4 @@ require "hyperloop/view/registry"
 require "hyperloop/view/scope"
 
 module Hyperloop
-  # Your code goes here...
 end

--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -6,38 +6,8 @@ module Hyperloop
     include Rack::Utils
 
     def initialize(root=nil)
-      @root       = root
-      @views_root = File.join([@root, "app/views"].compact)
-      layout_path = @views_root + "/layouts/application.html.erb"
-
-      # Get all the view paths. These look like:
-      #
-      # some/path/app/views/whatever.html.erb
-      # some/path/app/views/subdir/whatever.html.erb
-      view_paths = Dir.glob(@views_root + "/**/*").reject {|fn| File.directory?(fn)}
-
-      @views = view_paths.inject({}) do |result, path|
-        view = View.new(path, layout_path)
-
-        # The path under app/views. This will be something like:
-        #
-        # /whatever.html.erb
-        # /subdir/whatever.html.erb
-        relative_path = path.sub(@views_root, "")
-
-        # The path under app/views without a file extension. This will be
-        # something like:
-        #
-        # /whatever
-        # /subdir/whatever
-        request_dir  = File.split(relative_path).first
-        request_path = File.join(request_dir, view.name)
-
-        result[request_path] = view
-        result[request_dir]  = view if view.name == "index"
-
-        result
-      end
+      @root          = root
+      @view_registry = View::Registry.new(@root)
     end
 
     # Rack call interface.
@@ -52,7 +22,7 @@ module Hyperloop
         # as the response body.
         response["Content-Type"] = asset.content_type
         response.write(asset.source)
-      elsif view = @views[request_path]
+      elsif view = @view_registry.find_template_view(request_path)
         # If there's a view at the path, use its data as the response body.
         data = view.render(request)
         response.write(data)

--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -54,7 +54,7 @@ module Hyperloop
         response.write(asset.source)
       elsif view = @views[request_path]
         # If there's a view at the path, use its data as the response body.
-        data = view.render
+        data = view.render(request)
         response.write(data)
       else
         # If there's no view at the path, 404.

--- a/lib/hyperloop/view.rb
+++ b/lib/hyperloop/view.rb
@@ -7,7 +7,15 @@ module Hyperloop
       @view_registry = view_registry
       @full_path     = full_path
       @data          = File.read(@full_path)
-      @layout_data   = File.read(layout_path) if layout_path && File.file?(layout_path)
+
+      # Only load layout data if all of these things are true:
+      #
+      # 1. We're not in a partial
+      # 2. A layout path was provided
+      # 3. There's a file at the provided layout path
+      if !partial? && layout_path && File.file?(layout_path)
+        @layout_data = File.read(layout_path)
+      end
     end
 
     # Public: The format of the view. Derived from the view's extension.

--- a/lib/hyperloop/view.rb
+++ b/lib/hyperloop/view.rb
@@ -17,11 +17,19 @@ module Hyperloop
     end
 
     # Public: The name of the view. Derived from the view's filename without
-    # any extensions. Not guaranteed to be unique amongst other views in an app.
+    # any extensions or leading underscores. Not guaranteed to be unique amongst
+    # other views in an app.
     #
     # Returns a string.
     def name
-      @name ||= File.basename(@full_path).split(".").first
+      @name ||= filename.split(".").first.sub(/^_/, '')
+    end
+
+    # Public: Is this view a partial?
+    #
+    # Returns a boolean.
+    def partial?
+      @partial ||= filename.start_with?('_')
     end
 
     # Public: Render the view.
@@ -45,6 +53,12 @@ module Hyperloop
           view_html
         end
       end
+    end
+
+    private
+
+    def filename
+      filename ||= File.basename(@full_path)
     end
   end
 end

--- a/lib/hyperloop/view.rb
+++ b/lib/hyperloop/view.rb
@@ -26,17 +26,21 @@ module Hyperloop
 
     # Public: Render the view.
     #
+    # request - Rack request object that the view is being rendered in response
+    #           to.
+    #
     # Returns a string.
-    def render
+    def render(request)
       case format
       when :html
         @data
       when :erb
-        view_html = Tilt["erb"].new { @data }.render
+        scope     = Scope.new(request)
+        view_html = Tilt["erb"].new { @data }.render(scope)
 
         if @layout_data
           layout_template = Tilt["erb"].new { @layout_data }
-          layout_template.render { view_html }
+          layout_template.render(scope) { view_html }
         else
           view_html
         end

--- a/lib/hyperloop/view.rb
+++ b/lib/hyperloop/view.rb
@@ -3,10 +3,11 @@ require "tilt"
 
 module Hyperloop
   class View
-    def initialize(full_path, layout_path=nil)
-      @full_path   = full_path
-      @data        = File.read(@full_path)
-      @layout_data = File.read(layout_path) if layout_path && File.file?(layout_path)
+    def initialize(view_registry, full_path, layout_path=nil)
+      @view_registry = view_registry
+      @full_path     = full_path
+      @data          = File.read(@full_path)
+      @layout_data   = File.read(layout_path) if layout_path && File.file?(layout_path)
     end
 
     # Public: The format of the view. Derived from the view's extension.
@@ -43,7 +44,7 @@ module Hyperloop
       when :html
         @data
       when :erb
-        scope     = Scope.new(request)
+        scope     = Scope.new(request, @view_registry)
         view_html = Tilt["erb"].new { @data }.render(scope)
 
         if @layout_data

--- a/lib/hyperloop/view.rb
+++ b/lib/hyperloop/view.rb
@@ -31,14 +31,14 @@ module Hyperloop
     #
     # Returns a string.
     def name
-      @name ||= filename.split(".").first.sub(/^_/, '')
+      @name ||= filename.split(".").first.sub(/^_/, "")
     end
 
     # Public: Is this view a partial?
     #
     # Returns a boolean.
     def partial?
-      @partial ||= filename.start_with?('_')
+      @partial ||= filename.start_with?("_")
     end
 
     # Public: Render the view.

--- a/lib/hyperloop/view.rb
+++ b/lib/hyperloop/view.rb
@@ -67,7 +67,7 @@ module Hyperloop
     private
 
     def filename
-      filename ||= File.basename(@full_path)
+      @filename ||= File.basename(@full_path)
     end
   end
 end

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -2,6 +2,42 @@ module Hyperloop
   class View
     class Registry
       def initialize(root)
+        @root       = root
+        @views_root = File.join([@root, "app/views"].compact)
+        layout_path = @views_root + "/layouts/application.html.erb"
+
+        # Get all the view paths. These look like:
+        #
+        # some/path/app/views/whatever.html.erb
+        # some/path/app/views/subdir/whatever.html.erb
+        view_paths = Dir.glob(@views_root + "/**/*").reject {|fn| File.directory?(fn)}
+
+        @views = view_paths.inject({}) do |result, path|
+          view = View.new(path, layout_path)
+
+          # The path under app/views. This will be something like:
+          #
+          # /whatever.html.erb
+          # /subdir/whatever.html.erb
+          relative_path = path.sub(@views_root, "")
+
+          # The path under app/views without a file extension. This will be
+          # something like:
+          #
+          # /whatever
+          # /subdir/whatever
+          request_dir  = File.split(relative_path).first
+          request_path = File.join(request_dir, view.name)
+
+          result[request_path] = view
+          result[request_dir]  = view if view.name == "index"
+
+          result
+        end
+      end
+
+      def find_template_view(path)
+        @views[path]
       end
     end
   end

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -60,6 +60,25 @@ module Hyperloop
       def find_template_view(path)
         @template_views[path]
       end
+
+      # Public: Get the partial view for the specified path.
+      #
+      # path - Relative path for the view. Should start under the app/views
+      # directory and not include file extensions or leading underscores.
+      #
+      # Example:
+      #
+      #   Assuming there's a file at path/to/yoursite/app/views/subdir/_partial.html.erb
+      #
+      #   bad:  registry.find_partial_view("app/views/subdir/_partial.html.erb")
+      #   bad:  registry.find_partial_view("subdir/_partial.html.erb")
+      #   bad:  registry.find_partial_view("subdir/_partial")
+      #   good: registry.find_partial_view("subdir/partial")
+      #
+      # Returns a Hyperloop::View or nil if no view was found.
+      def find_partial_view(path)
+        @partial_views[path]
+      end
     end
   end
 end

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -2,16 +2,15 @@ module Hyperloop
   class View
     class Registry
       def initialize(root)
-        @root       = root
-        @views_root = File.join([@root, "app/views"].compact)
-        layout_path = @views_root + "/layouts/application.html.erb"
+        views_root  = File.join([root, "app/views"].compact)
+        layout_path = views_root + "/layouts/application.html.erb"
 
         # Get all the view paths. These look like:
         #
         # some/path/app/views/whatever.html.erb
         # some/path/app/views/subdir/whatever.html.erb
         # some/path/app/views/subdir/_partial.html.erb
-        view_paths = Dir.glob(@views_root + "/**/*").reject {|fn| File.directory?(fn)}
+        view_paths = Dir.glob(views_root + "/**/*").reject {|fn| File.directory?(fn)}
         view_paths -= [layout_path]
 
         @template_views = {}
@@ -25,7 +24,7 @@ module Hyperloop
           # /whatever.html.erb
           # /subdir/whatever.html.erb
           # /subdir/_partial.html.erb
-          relative_path = path.sub(@views_root, "")
+          relative_path = path.sub(views_root, "")
 
           # The path under app/views without a file extension (and without the
           # starting _ for partials). This will be something like:

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -12,6 +12,7 @@ module Hyperloop
         # some/path/app/views/subdir/whatever.html.erb
         # some/path/app/views/subdir/_partial.html.erb
         view_paths = Dir.glob(@views_root + "/**/*").reject {|fn| File.directory?(fn)}
+        view_paths -= [layout_path]
 
         @template_views = {}
         @partial_views  = {}

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -10,34 +10,42 @@ module Hyperloop
         #
         # some/path/app/views/whatever.html.erb
         # some/path/app/views/subdir/whatever.html.erb
+        # some/path/app/views/subdir/_partial.html.erb
         view_paths = Dir.glob(@views_root + "/**/*").reject {|fn| File.directory?(fn)}
 
-        @views = view_paths.inject({}) do |result, path|
+        @template_views = {}
+        @partial_views  = {}
+
+        view_paths.each do |path|
           view = View.new(path, layout_path)
 
           # The path under app/views. This will be something like:
           #
           # /whatever.html.erb
           # /subdir/whatever.html.erb
+          # /subdir/_partial.html.erb
           relative_path = path.sub(@views_root, "")
 
-          # The path under app/views without a file extension. This will be
-          # something like:
+          # The path under app/views without a file extension (and without the
+          # starting _ for partials). This will be something like:
           #
           # /whatever
           # /subdir/whatever
+          # /subdir/partial
           request_dir  = File.split(relative_path).first
           request_path = File.join(request_dir, view.name)
 
-          result[request_path] = view
-          result[request_dir]  = view if view.name == "index"
-
-          result
+          if view.partial?
+            @partial_views[request_path] = view
+          else
+            @template_views[request_path] = view
+            @template_views[request_dir]  = view if view.name == "index"
+          end
         end
       end
 
       def find_template_view(path)
-        @views[path]
+        @template_views[path]
       end
     end
   end

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -52,6 +52,8 @@ module Hyperloop
       #
       # Example:
       #
+      #   Assuming there's a file at path/to/yoursite/app/views/subdir/whatever.html.erb
+      #
       #   bad:  registry.find_template_view("app/views/subdir/whatever.html.erb")
       #   bad:  registry.find_template_view("subdir/whatever.html.erb")
       #   good: registry.find_template_view("subdir/whatever")

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -33,7 +33,7 @@ module Hyperloop
           # /whatever
           # /subdir/whatever
           # /subdir/partial
-          request_dir  = File.split(relative_path).first
+          request_dir  = File.dirname(relative_path)
           request_path = File.join(request_dir, view.name)
 
           if view.partial?

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -18,7 +18,7 @@ module Hyperloop
         @partial_views  = {}
 
         view_paths.each do |path|
-          view = View.new(path, layout_path)
+          view = View.new(self, path, layout_path)
 
           # The path under app/views. This will be something like:
           #
@@ -37,7 +37,8 @@ module Hyperloop
           request_path = File.join(request_dir, view.name)
 
           if view.partial?
-            @partial_views[request_path] = view
+            # Chop off the leading forward slash for partials.
+            @partial_views[request_path.sub(/^\//, "")] = view
           else
             @template_views[request_path] = view
             @template_views[request_dir]  = view if view.name == "index"
@@ -48,15 +49,17 @@ module Hyperloop
       # Public: Get the template view for the specified path.
       #
       # path - Relative path for the view. Should start under the app/views
-      # directory and not include file extensions.
+      # directory and not include file extensions. Should start with a forward
+      # slash.
       #
       # Example:
       #
       #   Assuming there's a file at path/to/yoursite/app/views/subdir/whatever.html.erb
       #
-      #   bad:  registry.find_template_view("app/views/subdir/whatever.html.erb")
-      #   bad:  registry.find_template_view("subdir/whatever.html.erb")
-      #   good: registry.find_template_view("subdir/whatever")
+      #   bad:  registry.find_template_view("/app/views/subdir/whatever.html.erb")
+      #   bad:  registry.find_template_view("/subdir/whatever.html.erb")
+      #   bad:  registry.find_template_view("subdir/whatever")
+      #   good: registry.find_template_view("/subdir/whatever")
       #
       # Returns a Hyperloop::View or nil if no view was found.
       def find_template_view(path)
@@ -66,7 +69,8 @@ module Hyperloop
       # Public: Get the partial view for the specified path.
       #
       # path - Relative path for the view. Should start under the app/views
-      # directory and not include file extensions or leading underscores.
+      # directory and not include file extensions, leading underscores, or
+      # leading forward slashes.
       #
       # Example:
       #
@@ -75,6 +79,7 @@ module Hyperloop
       #   bad:  registry.find_partial_view("app/views/subdir/_partial.html.erb")
       #   bad:  registry.find_partial_view("subdir/_partial.html.erb")
       #   bad:  registry.find_partial_view("subdir/_partial")
+      #   bad:  registry.find_partial_view("/subdir/partial")
       #   good: registry.find_partial_view("subdir/partial")
       #
       # Returns a Hyperloop::View or nil if no view was found.

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -45,6 +45,18 @@ module Hyperloop
         end
       end
 
+      # Public: Get the template view for the specified path.
+      #
+      # path - Relative path for the view. Should start under the app/views
+      # directory and not include file extensions.
+      #
+      # Example:
+      #
+      #   bad:  registry.find_template_view("app/views/subdir/whatever.html.erb")
+      #   bad:  registry.find_template_view("subdir/whatever.html.erb")
+      #   good: registry.find_template_view("subdir/whatever")
+      #
+      # Returns a Hyperloop::View or nil if no view was found.
       def find_template_view(path)
         @template_views[path]
       end

--- a/lib/hyperloop/view/registry.rb
+++ b/lib/hyperloop/view/registry.rb
@@ -1,0 +1,8 @@
+module Hyperloop
+  class View
+    class Registry
+      def initialize(root)
+      end
+    end
+  end
+end

--- a/lib/hyperloop/view/scope.rb
+++ b/lib/hyperloop/view/scope.rb
@@ -1,3 +1,5 @@
+require 'tilt'
+
 module Hyperloop
   class View
     class Scope
@@ -13,7 +15,10 @@ module Hyperloop
       #
       # Returns a string.
       def render(path)
-        path
+        # lol
+        view_path = File.join("spec/fixtures/partials/app/views", File.dirname(path), "_" + File.basename(path)) + ".html.erb"
+        data = File.read(view_path)
+        Tilt["erb"].new { data }.render(self)
       end
     end
   end

--- a/lib/hyperloop/view/scope.rb
+++ b/lib/hyperloop/view/scope.rb
@@ -1,0 +1,11 @@
+module Hyperloop
+  class View
+    class Scope
+      attr_reader :request
+
+      def initialize(request)
+        @request = request
+      end
+    end
+  end
+end

--- a/lib/hyperloop/view/scope.rb
+++ b/lib/hyperloop/view/scope.rb
@@ -5,8 +5,9 @@ module Hyperloop
     class Scope
       attr_reader :request
 
-      def initialize(request)
-        @request = request
+      def initialize(request, view_registry)
+        @request       = request
+        @view_registry = view_registry
       end
 
       # Public: Render the specified partial.
@@ -15,10 +16,7 @@ module Hyperloop
       #
       # Returns a string.
       def render(path)
-        # lol
-        view_path = File.join("spec/fixtures/partials/app/views", File.dirname(path), "_" + File.basename(path)) + ".html.erb"
-        data = File.read(view_path)
-        Tilt["erb"].new { data }.render(self)
+        @view_registry.find_partial_view(path).render(request)
       end
     end
   end

--- a/lib/hyperloop/view/scope.rb
+++ b/lib/hyperloop/view/scope.rb
@@ -6,6 +6,15 @@ module Hyperloop
       def initialize(request)
         @request = request
       end
+
+      # Public: Render the specified partial.
+      #
+      # path - Path to look for the partial at.
+      #
+      # Returns a string.
+      def render(path)
+        path
+      end
     end
   end
 end

--- a/lib/hyperloop/view/scope.rb
+++ b/lib/hyperloop/view/scope.rb
@@ -1,4 +1,4 @@
-require 'tilt'
+require "tilt"
 
 module Hyperloop
   class View

--- a/spec/fixtures/partials/app/views/index.html.erb
+++ b/spec/fixtures/partials/app/views/index.html.erb
@@ -1,3 +1,3 @@
 <h2>This part of the root page is not in a partial!</h2>
 
-<%= render :partial => "subdir/partial" %>
+<%= render "subdir/partial" %>

--- a/spec/fixtures/partials/app/views/index.html.erb
+++ b/spec/fixtures/partials/app/views/index.html.erb
@@ -1,0 +1,3 @@
+<h2>This part of the root page is not in a partial!</h2>
+
+<%= render :partial => "subdir/partial" %>

--- a/spec/fixtures/partials/app/views/layouts/application.html.erb
+++ b/spec/fixtures/partials/app/views/layouts/application.html.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>App With Partials</title>
+  </head>
+
+  <body>
+    <h1>Partials work in this app</h1>
+
+    <%= yield %>
+  </body>
+</html>

--- a/spec/fixtures/partials/app/views/subdir/_partial.html.erb
+++ b/spec/fixtures/partials/app/views/subdir/_partial.html.erb
@@ -1,0 +1,1 @@
+<p>This is coming from a partial.</p>

--- a/spec/fixtures/partials/app/views/subdir/index.html.erb
+++ b/spec/fixtures/partials/app/views/subdir/index.html.erb
@@ -1,0 +1,3 @@
+<h2>This is a page in a subdirectory!</h2>
+
+<p>How u doin.</p>

--- a/spec/fixtures/partials/app/views/subdir/nonroot.html.erb
+++ b/spec/fixtures/partials/app/views/subdir/nonroot.html.erb
@@ -1,0 +1,3 @@
+<h2>This is not the root!</h2>
+
+<p>But it's still cool.</p>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,8 +17,7 @@ module Helpers
 
   def text_in(html_str, selector)
     node = html(html_str).at_css(selector)
-    raise "Selector #{selector.inspect} not found in:\n\n#{html_str.inspect}" unless node
-    node.text
+    node && node.text
   end
 
   def mock_app

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,13 @@ module Helpers
     Nokogiri::HTML(str)
   end
 
+  def mock_view_registry
+    @mock_view_registry ||= double("Hyperloop::View::Registry",
+      :find_partial_view  => nil,
+      :find_template_view => nil
+    )
+  end
+
   def text_in(html_str, selector)
     node = html(html_str).at_css(selector)
     raise "Selector #{selector.inspect} not found in:\n\n#{html_str.inspect}" unless node

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,14 @@ module Helpers
     raise "Selector #{selector.inspect} not found in:\n\n#{html_str.inspect}" unless node
     node.text
   end
+
+  def mock_app
+    @mock_app ||= double("rack app", :call => Hyperloop::Response.new.finish )
+  end
+
+  def mock_request
+    Rack::MockRequest.new(mock_app)
+  end
 end
 
 RSpec.configure do |c|

--- a/spec/view/registry_spec.rb
+++ b/spec/view/registry_spec.rb
@@ -22,7 +22,7 @@ describe Hyperloop::View::Registry do
     end
 
     it "doesn't find layouts" do
-      expect(@registry.find_template_view("/subdir/layouts/application")).to be_nil
+      expect(@registry.find_template_view("/layouts/application")).to be_nil
     end
   end
 

--- a/spec/view/registry_spec.rb
+++ b/spec/view/registry_spec.rb
@@ -19,6 +19,8 @@ describe Hyperloop::View::Registry do
     it "doesn't find partials" do
       expect(@registry.find_template_view("/subdir/partial")).to be_nil
       expect(@registry.find_template_view("/subdir/_partial")).to be_nil
+      expect(@registry.find_template_view("subdir/partial")).to be_nil
+      expect(@registry.find_template_view("subdir/_partial")).to be_nil
     end
 
     it "doesn't find layouts" do
@@ -28,21 +30,27 @@ describe Hyperloop::View::Registry do
 
   describe "#find_partial_view" do
     it "finds partials" do
-      expect(@registry.find_partial_view("/subdir/partial").name).to eql("partial")
+      expect(@registry.find_partial_view("subdir/partial").name).to eql("partial")
     end
 
     it "doesn't find partials if the filename in the path is prefixed with an underscore" do
-      expect(@registry.find_partial_view("/subdir/_partial")).to be_nil
+      expect(@registry.find_partial_view("subdir/_partial")).to be_nil
+    end
+
+    it "doesn't find partials if the path is prefixed with a forward slash" do
+      expect(@registry.find_partial_view("/subdir/partial")).to be_nil
     end
 
     it "doesn't find template views" do
       expect(@registry.find_partial_view("/")).to be_nil
       expect(@registry.find_partial_view("/subdir")).to be_nil
       expect(@registry.find_partial_view("/subdir/nonroot")).to be_nil
+      expect(@registry.find_partial_view("subdir/nonroot")).to be_nil
     end
 
     it "doesn't find layouts" do
       expect(@registry.find_partial_view("/subdir/layouts/application")).to be_nil
+      expect(@registry.find_partial_view("subdir/layouts/application")).to be_nil
     end
   end
 end

--- a/spec/view/registry_spec.rb
+++ b/spec/view/registry_spec.rb
@@ -1,0 +1,48 @@
+describe Hyperloop::View::Registry do
+  before :each do
+    @registry = Hyperloop.registry.new("spec/fixtures/partials/")
+  end
+
+  describe "#find_template_view" do
+    it "finds the root view" do
+      expect(@registry.find_template_view("/").name).to eql("index")
+    end
+
+    it "finds a root view in a subdirectory" do
+      expect(@registry.find_template_view("/subdir").name).to eql("index")
+    end
+
+    it "finds a non-root view in a subdirectory" do
+      expect(@registry.find_template_view("/subdir/nonroot").name).to eql("nonroot")
+    end
+
+    it "doesn't find partials" do
+      expect(@registry.find_template_view("/subdir/partial")).to be_nil
+      expect(@registry.find_template_view("/subdir/_partial")).to be_nil
+    end
+
+    it "doesn't find layouts" do
+      expect(@registry.find_template_view("/subdir/layouts/application")).to be_nil
+    end
+  end
+
+  describe "#find_partial_view" do
+    it "finds partials" do
+      expect(@registry.find_partial_view("/subdir/partial").name).to eql("partial")
+    end
+
+    it "doesn't find partials if the filename in the path is prefixed with an underscore" do
+      expect(@registry.find_partial_view("/subdir/_partial")).to be_nil
+    end
+
+    it "doesn't find template views" do
+      expect(@registry.find_partial_view("/")).to be_nil
+      expect(@registry.find_partial_view("/subdir")).to be_nil
+      expect(@registry.find_partial_view("/subdir/nonroot")).to be_nil
+    end
+
+    it "doesn't find layouts" do
+      expect(@registry.find_partial_view("/subdir/layouts/application")).to be_nil
+    end
+  end
+end

--- a/spec/view/registry_spec.rb
+++ b/spec/view/registry_spec.rb
@@ -1,6 +1,6 @@
 describe Hyperloop::View::Registry do
   before :each do
-    @registry = Hyperloop.registry.new("spec/fixtures/partials/")
+    @registry = Hyperloop::View::Registry.new("spec/fixtures/partials/")
   end
 
   describe "#find_template_view" do

--- a/spec/view/scope_spec.rb
+++ b/spec/view/scope_spec.rb
@@ -1,7 +1,6 @@
 describe Hyperloop::View::Scope do
   before :each do
-    app      = Hyperloop::Application.new("spec/fixtures/simple/")
-    @request = Rack::MockRequest.new(app)
+    @request = Rack::MockRequest.new(mock_app)
     @scope   = Hyperloop::View::Scope.new(@request)
   end
 

--- a/spec/view/scope_spec.rb
+++ b/spec/view/scope_spec.rb
@@ -1,7 +1,7 @@
 describe Hyperloop::View::Scope do
   before :each do
     @request = Rack::MockRequest.new(mock_app)
-    @scope   = Hyperloop::View::Scope.new(@request)
+    @scope   = Hyperloop::View::Scope.new(@request, mock_view_registry)
   end
 
   describe "#request" do

--- a/spec/view/scope_spec.rb
+++ b/spec/view/scope_spec.rb
@@ -1,0 +1,13 @@
+describe Hyperloop::View::Scope do
+  before :each do
+    app      = Hyperloop::Application.new("spec/fixtures/simple/")
+    @request = Rack::MockRequest.new(app)
+    @scope   = Hyperloop::View::Scope.new(@request)
+  end
+
+  describe "#request" do
+    it "is the request that the scope will be used in response to" do
+      expect(@scope.request).to eql(@request)
+    end
+  end
+end

--- a/spec/view/scope_spec.rb
+++ b/spec/view/scope_spec.rb
@@ -1,12 +1,21 @@
 describe Hyperloop::View::Scope do
   before :each do
-    @request = Rack::MockRequest.new(mock_app)
-    @scope   = Hyperloop::View::Scope.new(@request, mock_view_registry)
+    view_registry = Hyperloop::View::Registry.new("spec/fixtures/partials/")
+    @request      = Rack::MockRequest.new(mock_app)
+    @scope        = Hyperloop::View::Scope.new(@request, view_registry)
   end
 
   describe "#request" do
     it "is the request that the scope will be used in response to" do
       expect(@scope.request).to eql(@request)
+    end
+  end
+
+  describe "#render" do
+    it "renders the specified partial" do
+      html = @scope.render("subdir/partial")
+
+      expect(text_in(html, "p")).to eql("This is coming from a partial.")
     end
   end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -8,6 +8,10 @@ describe Hyperloop::View do
       "spec/fixtures/layouts/app/views/index.html.erb",
       "spec/fixtures/layouts/app/views/layouts/application.html.erb"
     )
+    @partial_view = Hyperloop::View.new(
+      "spec/fixtures/partials/app/views/index.html.erb",
+      "spec/fixtures/partials/app/views/layouts/application.html.erb"
+    )
   end
 
   describe "#format" do
@@ -44,6 +48,14 @@ describe Hyperloop::View do
 
       expect(text_in(html, "h1")).to eql("Layout Header")
       expect(text_in(html, "h2")).to eql("This is the root page!")
+    end
+
+    it "renders partials in ERB files" do
+      html = @partial_view.render
+
+      expect(text_in(html, "h1")).to eql("Partials work in this app")
+      expect(text_in(html, "h2")).to eql("This part of the root page is not in a partial!")
+      expect(text_in(html, "p")).to eql("This is coming from a partial.")
     end
   end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -36,22 +36,26 @@ describe Hyperloop::View do
 
   describe "#render" do
     it "renders plain HTML files" do
-      expect(text_in(@html_view.render, "h1")).to eql("About")
+      html = @html_view.render(mock_request)
+
+      expect(text_in(html, "h1")).to eql("About")
     end
 
     it "renders ERB files" do
-      expect(text_in(@erb_view.render, "h1")).to eql("I was born on December 21")
+      html = @erb_view.render(mock_request)
+
+      expect(text_in(html, "h1")).to eql("I was born on December 21")
     end
 
     it "renders ERB files in layouts" do
-      html = @layout_view.render
+      html = @layout_view.render(mock_request)
 
       expect(text_in(html, "h1")).to eql("Layout Header")
       expect(text_in(html, "h2")).to eql("This is the root page!")
     end
 
     it "renders partials in ERB files" do
-      html = @partial_view.render
+      html = @partial_view.render(mock_request)
 
       expect(text_in(html, "h1")).to eql("Partials work in this app")
       expect(text_in(html, "h2")).to eql("This part of the root page is not in a partial!")

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -2,21 +2,22 @@ require File.expand_path("../spec_helper", __FILE__)
 
 describe Hyperloop::View do
   before :each do
-    @html_view   = Hyperloop::View.new("spec/fixtures/simple/app/views/about.html")
-    @erb_view    = Hyperloop::View.new("spec/fixtures/erb/app/views/about.html.erb")
-    @layout_view = Hyperloop::View.new(
+    @html_view = Hyperloop::View.new(mock_view_registry,
+      "spec/fixtures/simple/app/views/about.html"
+    )
+
+    @erb_view = Hyperloop::View.new(mock_view_registry,
+      "spec/fixtures/erb/app/views/about.html.erb"
+    )
+
+    @layout_view = Hyperloop::View.new(mock_view_registry,
       "spec/fixtures/layouts/app/views/index.html.erb",
       "spec/fixtures/layouts/app/views/layouts/application.html.erb"
     )
 
-    @partial_container = Hyperloop::View.new(
-      "spec/fixtures/partials/app/views/index.html.erb",
-      "spec/fixtures/partials/app/views/layouts/application.html.erb"
-    )
-    @partial_view = Hyperloop::View.new(
-      "spec/fixtures/partials/app/views/subdir/_partial.html.erb",
-      nil
-    )
+    partials_view_registry = Hyperloop::View::Registry.new("spec/fixtures/partials/")
+    @partial_container     = partials_view_registry.find_template_view("/")
+    @partial_view          = partials_view_registry.find_partial_view("subdir/partial")
   end
 
   describe "#format" do
@@ -73,7 +74,7 @@ describe Hyperloop::View do
       expect(text_in(html, "h2")).to eql("This is the root page!")
     end
 
-    it "renders partials in ERB files" do
+    it "renders ERB files containing partials" do
       html = @partial_container.render(mock_request)
 
       expect(text_in(html, "h1")).to eql("Partials work in this app")

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -81,5 +81,13 @@ describe Hyperloop::View do
       expect(text_in(html, "h2")).to eql("This part of the root page is not in a partial!")
       expect(text_in(html, "p")).to eql("This is coming from a partial.")
     end
+
+    it "renders ERB partials" do
+      html = @partial_view.render(mock_request)
+
+      expect(text_in(html, "h1")).not_to eql("Partials work in this app")
+      expect(text_in(html, "h2")).not_to eql("This part of the root page is not in a partial!")
+      expect(text_in(html, "p")).to eql("This is coming from a partial.")
+    end
   end
 end

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -8,9 +8,14 @@ describe Hyperloop::View do
       "spec/fixtures/layouts/app/views/index.html.erb",
       "spec/fixtures/layouts/app/views/layouts/application.html.erb"
     )
-    @partial_view = Hyperloop::View.new(
+
+    @partial_container = Hyperloop::View.new(
       "spec/fixtures/partials/app/views/index.html.erb",
       "spec/fixtures/partials/app/views/layouts/application.html.erb"
+    )
+    @partial_view = Hyperloop::View.new(
+      "spec/fixtures/partials/app/views/subdir/_partial.html.erb",
+      nil
     )
   end
 
@@ -31,6 +36,20 @@ describe Hyperloop::View do
 
     it "strips the extension from ERB files" do
       expect(@erb_view.name).to eql("about")
+    end
+
+    it "strips the leading underscore for partials" do
+      expect(@partial_view.name).to eql("partial")
+    end
+  end
+
+  describe "#partial?" do
+    it "is false for a template view" do
+      expect(@partial_container).not_to be_partial
+    end
+
+    it "is true for a partial view" do
+      expect(@partial_view).to be_partial
     end
   end
 
@@ -55,7 +74,7 @@ describe Hyperloop::View do
     end
 
     it "renders partials in ERB files" do
-      html = @partial_view.render(mock_request)
+      html = @partial_container.render(mock_request)
 
       expect(text_in(html, "h1")).to eql("Partials work in this app")
       expect(text_in(html, "h2")).to eql("This part of the root page is not in a partial!")


### PR DESCRIPTION
This branch implements partials. They work the same way as they do in Rails:

``` erb
<%# Assume there's a file at app/views/subdir/_partial.html.erb %>

<h1>This comes before the partial.</h1>

<%= render "subdir/partial" %>

<p>This comes after the partial.</p>
```

The actual rendering of partials is pretty easy. You can see a super dumb implementation in 57d2b269613b4ad71fbecc3864a3cca04db4c37d. Most of the important stuff in this pull is refactoring. I'll outline the two important parts here:
### `View::Scope`

[rtomayko/tilt](https://github.com/rtomayko/tilt/tree/tilt-1) allows a "scope" to be passed to `Template#render`. The scope is just an object that defines the methods you can use in the template. So, if a template has `<%= pluralize("dog") %>`, it'll look for a `pluralize` method in the scope object you passed to `Template#render`.

This branch adds `View::Scope`, which includes the `View::Scope#render` method. This is what lets us do `<%= render "subdir/partial" %>` in templates.
### `View::Registry`

Previously, views were loaded in `Application.new`, and looked up in `Application#call`. Now, `Application.new` creates a new `View::Registry`, which handles loading the views (in `View::Registry.new`) and looking them up (in `View::Registry#find_template_view`). It also handles looking up partials with `View::Registry#find_partial_view`, which `View::Scope#render` (described above) calls.

/cc @jessicard 
