### PR TITLE
Add live reload in development/test

### DIFF
--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -12,9 +12,8 @@ module Hyperloop
 
     # Rack call interface.
     def call(env)
-      view_registry = View::Registry.new(@root)
-      request       = Rack::Request.new(env)
-      response      = Response.new
+      request  = Rack::Request.new(env)
+      response = Response.new
 
       if self.class.asset_path?(request.path) && asset = assets[normalized_asset_path(request.path)]
         # If the path is for an asset, find the specified asset and use its data
@@ -95,6 +94,21 @@ module Hyperloop
     # Returns a boolean.
     def production?
       ENV["RACK_ENV"] == "production"
+    end
+
+    # Internal: The view registry to use for the app.
+    #
+    # Returns a Hyperloop::View::Registry
+    def view_registry
+      return @view_registry if @view_registry
+
+      registry = View::Registry.new(@root)
+
+      # Memoize if we're in production so we don't reload views on every
+      # request.
+      @view_registry = registry if production?
+
+      registry
     end
   end
 end

--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -7,21 +7,21 @@ module Hyperloop
     include Rack::Utils
 
     def initialize(root=nil)
-      @root          = root
-      @view_registry = View::Registry.new(@root)
+      @root = root
     end
 
     # Rack call interface.
     def call(env)
-      request  = Rack::Request.new(env)
-      response = Response.new
+      view_registry = View::Registry.new(@root)
+      request       = Rack::Request.new(env)
+      response      = Response.new
 
       if self.class.asset_path?(request.path) && asset = assets[normalized_asset_path(request.path)]
         # If the path is for an asset, find the specified asset and use its data
         # as the response body.
         response["Content-Type"] = asset.content_type
         response.write(asset.source)
-      elsif view = @view_registry.find_template_view(normalized_request_path(request.path))
+      elsif view = view_registry.find_template_view(normalized_request_path(request.path))
         # If there's a view at the path, use its data as the response body.
         data = view.render(request)
         response.write(data)

--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -48,7 +48,7 @@ module Hyperloop
     #
     # Returns a Sprockets::Environment.
     def assets
-      @assets ||= Sprockets::Environment.new do |env|
+      Sprockets::Environment.new do |env|
         env.append_path(File.join(@root, "app", "assets"))
         env.append_path(File.join(@root, "vendor", "assets"))
 

--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -96,15 +96,8 @@ module Hyperloop
     #
     # Returns a Hyperloop::View::Registry
     def view_registry
-      return @view_registry if @view_registry
-
-      registry = View::Registry.new(@root)
-
-      # Memoize if we're in production so we don't reload views on every
-      # request.
-      @view_registry = registry if production?
-
-      registry
+      @view_registry = nil unless production?
+      @view_registry ||= View::Registry.new(@root)
     end
   end
 end

--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -50,6 +50,8 @@ module Hyperloop
       return @assets if @assets
 
       sprockets_env = Sprockets::Environment.new do |env|
+        env.version = ENV["RACK_ENV"]
+
         env.append_path(File.join(@root, "app", "assets"))
         env.append_path(File.join(@root, "vendor", "assets"))
 

--- a/lib/hyperloop/application.rb
+++ b/lib/hyperloop/application.rb
@@ -47,13 +47,13 @@ module Hyperloop
     #
     # Returns a Sprockets::Environment.
     def assets
-      return @assets if @assets
+      @assets = nil unless production?
 
-      sprockets_env = Sprockets::Environment.new do |env|
+      @assets ||= Sprockets::Environment.new(@root) do |env|
         env.version = ENV["RACK_ENV"]
 
-        env.append_path(File.join(@root, "app", "assets"))
-        env.append_path(File.join(@root, "vendor", "assets"))
+        env.append_path(File.join("app", "assets"))
+        env.append_path(File.join("vendor", "assets"))
 
         # compress everything in production
         if production?
@@ -61,12 +61,6 @@ module Hyperloop
           env.css_compressor = YUI::CssCompressor.new
         end
       end
-
-      # Memoize if we're in production so we don't reload assets on every
-      # request.
-      @assets = sprockets_env if production?
-
-      sprockets_env
     end
 
     # Internal: Get a normalized version of the specified asset path.

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -330,7 +330,7 @@ describe Hyperloop::Application do
         # Load index.html.erb and change the title to "Changed"
         index_file_path = File.join(root, "app", "views", "index.html.erb")
         index_file_data = File.read(index_file_path)
-        index_file_data.sub!(/<h2>[^<]*<\/h2>/, "<h2>Changed</h2>")
+        index_file_data.sub!("<title>ERB</title>", "<title>Changed</title>")
         File.write(index_file_path, index_file_data)
 
         # On the second request, <title> text should still be "ERB"

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -1,9 +1,13 @@
 require File.expand_path("../spec_helper", __FILE__)
 
 describe Hyperloop::Application do
+  after :each do
+    cleanup_fixtures
+  end
+
   describe "with a flat views directory" do
     before :each do
-      @app     = Hyperloop::Application.new("spec/fixtures/simple/")
+      @app     = Hyperloop::Application.new(prepare_fixture(:simple))
       @request = Rack::MockRequest.new(@app)
     end
 

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -1,10 +1,6 @@
 require File.expand_path("../spec_helper", __FILE__)
 
 describe Hyperloop::Application do
-  after :each do
-    cleanup_fixtures
-  end
-
   describe "with a flat views directory" do
     before :each do
       @app = Hyperloop::Application.new(prepare_fixture(:simple))

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -42,7 +42,7 @@ describe Hyperloop::Application do
 
   describe "with subdirectories" do
     before :each do
-      @app     = Hyperloop::Application.new("spec/fixtures/subdirectories/")
+      @app     = Hyperloop::Application.new(prepare_fixture(:subdirectories))
       @request = Rack::MockRequest.new(@app)
     end
 
@@ -63,7 +63,7 @@ describe Hyperloop::Application do
 
   describe "with ERB" do
     before :each do
-      @app     = Hyperloop::Application.new("spec/fixtures/erb/")
+      @app     = Hyperloop::Application.new(prepare_fixture(:erb))
       @request = Rack::MockRequest.new(@app)
     end
 
@@ -77,7 +77,7 @@ describe Hyperloop::Application do
 
   describe "with a layout" do
     before :each do
-      @app     = Hyperloop::Application.new("spec/fixtures/layouts/")
+      @app     = Hyperloop::Application.new(prepare_fixture(:layouts))
       @request = Rack::MockRequest.new(@app)
     end
 
@@ -100,7 +100,7 @@ describe Hyperloop::Application do
 
   describe "with assets" do
     before :each do
-      @app     = Hyperloop::Application.new("spec/fixtures/assets/")
+      @app     = Hyperloop::Application.new(prepare_fixture(:assets))
       @request = Rack::MockRequest.new(@app)
     end
 

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -7,12 +7,11 @@ describe Hyperloop::Application do
 
   describe "with a flat views directory" do
     before :each do
-      @app     = Hyperloop::Application.new(prepare_fixture(:simple))
-      @request = Rack::MockRequest.new(@app)
+      @app = Hyperloop::Application.new(prepare_fixture(:simple))
     end
 
     it "responds successfully to a request for root" do
-      response = @request.get("/")
+      response = mock_request(@app).get("/")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("text/html")
@@ -20,21 +19,21 @@ describe Hyperloop::Application do
     end
 
     it "responds successfully to a request for a different page" do
-      response = @request.get("/about")
+      response = mock_request(@app).get("/about")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("About")
     end
 
     it "responds successfully to a request with a trailing slash" do
-      response = @request.get("/about/")
+      response = mock_request(@app).get("/about/")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("About")
     end
 
     it "404s on a request for a nonexistent page" do
-      response = @request.get("/nonexistent")
+      response = mock_request(@app).get("/nonexistent")
 
       expect(response).to be_not_found
     end
@@ -42,19 +41,18 @@ describe Hyperloop::Application do
 
   describe "with subdirectories" do
     before :each do
-      @app     = Hyperloop::Application.new(prepare_fixture(:subdirectories))
-      @request = Rack::MockRequest.new(@app)
+      @app = Hyperloop::Application.new(prepare_fixture(:subdirectories))
     end
 
     it "responds successfully to a request for the subdirectory root" do
-      response = @request.get("/subdir1")
+      response = mock_request(@app).get("/subdir1")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("Subdirectory Index")
     end
 
     it "responds successfully to a request for a different page in the subdirectory" do
-      response = @request.get("/subdir1/kanye")
+      response = mock_request(@app).get("/subdir1/kanye")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("Hurry up with my damn croissant")
@@ -63,12 +61,11 @@ describe Hyperloop::Application do
 
   describe "with ERB" do
     before :each do
-      @app     = Hyperloop::Application.new(prepare_fixture(:erb))
-      @request = Rack::MockRequest.new(@app)
+      @app = Hyperloop::Application.new(prepare_fixture(:erb))
     end
 
     it "renders embedded Ruby in the root page" do
-      response = @request.get("/")
+      response = mock_request(@app).get("/")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("WE ARE USING ERB")
@@ -77,12 +74,11 @@ describe Hyperloop::Application do
 
   describe "with a layout" do
     before :each do
-      @app     = Hyperloop::Application.new(prepare_fixture(:layouts))
-      @request = Rack::MockRequest.new(@app)
+      @app = Hyperloop::Application.new(prepare_fixture(:layouts))
     end
 
     it "renders the root view within the layout" do
-      response = @request.get("/")
+      response = mock_request(@app).get("/")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("Layout Header")
@@ -90,7 +86,7 @@ describe Hyperloop::Application do
     end
 
     it "renders subdirectory views within the layout" do
-      response = @request.get("/subdir")
+      response = mock_request(@app).get("/subdir")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("Layout Header")
@@ -100,19 +96,18 @@ describe Hyperloop::Application do
 
   describe "with assets" do
     before :each do
-      @app     = Hyperloop::Application.new(prepare_fixture(:assets))
-      @request = Rack::MockRequest.new(@app)
+      @app = Hyperloop::Application.new(prepare_fixture(:assets))
     end
 
     it "responds successfully to a request for root" do
-      response = @request.get("/")
+      response = mock_request(@app).get("/")
 
       expect(response).to be_ok
       expect(text_in(response.body, "h1")).to eql("This app has so many assets")
     end
 
     it "responds successfully to a request for the css app bundle" do
-      response = @request.get("/assets/stylesheets/app.css")
+      response = mock_request(@app).get("/assets/stylesheets/app.css")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("text/css")
@@ -120,7 +115,7 @@ describe Hyperloop::Application do
     end
 
     it "responds successfully to a request for the javascript app bundle" do
-      response = @request.get("/assets/javascripts/app.js")
+      response = mock_request(@app).get("/assets/javascripts/app.js")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("application/javascript")
@@ -128,7 +123,7 @@ describe Hyperloop::Application do
     end
 
     it "responds successfully to a request for a vendored css file" do
-      response = @request.get("/assets/stylesheets/vendored.css")
+      response = mock_request(@app).get("/assets/stylesheets/vendored.css")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("text/css")
@@ -136,7 +131,7 @@ describe Hyperloop::Application do
     end
 
     it "responds successfully to a request for a vendored javascript bundle" do
-      response = @request.get("/assets/javascripts/vendored.js")
+      response = mock_request(@app).get("/assets/javascripts/vendored.js")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("application/javascript")
@@ -144,7 +139,7 @@ describe Hyperloop::Application do
     end
 
     it "responds successfully to a request for a gif" do
-      response = @request.get("/assets/images/my-gif.gif")
+      response = mock_request(@app).get("/assets/images/my-gif.gif")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("image/gif")
@@ -152,7 +147,7 @@ describe Hyperloop::Application do
     end
 
     it "responds successfully to a request for a jpg" do
-      response = @request.get("/assets/images/my-jpg.jpg")
+      response = mock_request(@app).get("/assets/images/my-jpg.jpg")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("image/jpeg")
@@ -160,7 +155,7 @@ describe Hyperloop::Application do
     end
 
     it "responds successfully to a request for a png" do
-      response = @request.get("/assets/images/my-png.png")
+      response = mock_request(@app).get("/assets/images/my-png.png")
 
       expect(response).to be_ok
       expect(response.content_type).to eql("image/png")
@@ -168,22 +163,22 @@ describe Hyperloop::Application do
     end
 
     it "404s on a request for an asset without namespacing by type" do
-      response = @request.get("/assets/app.js")
+      response = mock_request(@app).get("/assets/app.js")
       expect(response).to be_not_found
     end
 
     it "404s on a request for an asset namespaced by the wrong type" do
-      response = @request.get("/assets/stylesheets/app.js")
+      response = mock_request(@app).get("/assets/stylesheets/app.js")
       expect(response).to be_not_found
     end
 
     it "404s on a request for an asset namespaced by an unknown type" do
-      response = @request.get("/assets/shouldfail/shouldfail.css")
+      response = mock_request(@app).get("/assets/shouldfail/shouldfail.css")
       expect(response).to be_not_found
     end
 
     it "404s on a request for a nonexistent asset" do
-      response = @request.get("/assets/javascripts/nonexistent.js")
+      response = mock_request(@app).get("/assets/javascripts/nonexistent.js")
 
       expect(response).to be_not_found
     end
@@ -192,15 +187,14 @@ describe Hyperloop::Application do
   describe "live reloading" do
     context "with assets" do
       before :each do
-        @root    = prepare_fixture(:assets)
-        @app     = Hyperloop::Application.new(@root)
-        @request = Rack::MockRequest.new(@app)
+        @root = prepare_fixture(:assets)
+        @app  = Hyperloop::Application.new(@root)
       end
 
       it "reloads changed assets" do
         # On the first request, stylesheet should have `display: block` and not
         # `display: inline`.
-        response = @request.get("/assets/stylesheets/app.css")
+        response = mock_request(@app).get("/assets/stylesheets/app.css")
         expect(response).to be_ok
         expect(response.body).to match(/display: ?block/)
         expect(response.body).not_to match(/display: ?inline/)
@@ -212,7 +206,7 @@ describe Hyperloop::Application do
 
         # On the second request, stylesheet should have `display: inline` and not
         # `display: block`.
-        response = @request.get("/assets/stylesheets/app.css")
+        response = mock_request(@app).get("/assets/stylesheets/app.css")
         expect(response).to be_ok
         expect(response.body).to match(/display: ?inline/)
         expect(response.body).not_to match(/display: ?block/)
@@ -221,14 +215,13 @@ describe Hyperloop::Application do
 
     context "with views" do
       before :each do
-        @root    = prepare_fixture(:partials)
-        @app     = Hyperloop::Application.new(@root)
-        @request = Rack::MockRequest.new(@app)
+        @root = prepare_fixture(:partials)
+        @app  = Hyperloop::Application.new(@root)
       end
 
       it "reloads changed layouts" do
         # On the first request, <title> text should not be "Changed"
-        response = @request.get("/")
+        response = mock_request(@app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "title")).not_to eql("Changed")
 
@@ -238,14 +231,14 @@ describe Hyperloop::Application do
         )
 
         # On the second request, <title> text should be "Changed"
-        response = @request.get("/")
+        response = mock_request(@app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "title")).to eql("Changed")
       end
 
       it "reloads changed partials" do
         # On the first request, <p> text should not be "Changed"
-        response = @request.get("/")
+        response = mock_request(@app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "p.spec-in-partial")).not_to eql("Changed")
 
@@ -255,14 +248,14 @@ describe Hyperloop::Application do
         )
 
         # On the second request, <p> text should be "Changed"
-        response = @request.get("/")
+        response = mock_request(@app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "p.spec-in-partial")).to eql("Changed")
       end
 
       it "reloads changed views" do
         # On the first request, <h2> text should not be "Changed"
-        response = @request.get("/")
+        response = mock_request(@app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "h2")).not_to eql("Changed")
 
@@ -272,7 +265,7 @@ describe Hyperloop::Application do
         )
 
         # On the second request, <h2> text should be "Changed"
-        response = @request.get("/")
+        response = mock_request(@app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "h2")).to eql("Changed")
       end
@@ -288,13 +281,12 @@ describe Hyperloop::Application do
       end
 
       it "doesn't reload changed assets" do
-        root    = prepare_fixture(:assets)
-        app     = Hyperloop::Application.new(root)
-        request = Rack::MockRequest.new(app)
+        root = prepare_fixture(:assets)
+        app  = Hyperloop::Application.new(root)
 
         # On the first request, stylesheet should have `display: block` and not
         # `display: inline`.
-        response = request.get("/assets/stylesheets/app.css")
+        response = mock_request(app).get("/assets/stylesheets/app.css")
         expect(response).to be_ok
         expect(response.body).to match(/display: ?block/)
         expect(response.body).not_to match(/display: ?inline/)
@@ -306,19 +298,18 @@ describe Hyperloop::Application do
 
         # On the second request, stylesheet should still have `display: block`
         # and not `display: inline`.
-        response = request.get("/assets/stylesheets/app.css")
+        response = mock_request(app).get("/assets/stylesheets/app.css")
         expect(response).to be_ok
         expect(response.body).to match(/display: ?block/)
         expect(response.body).not_to match(/display: ?inline/)
       end
 
       it "doesn't reload changed views" do
-        root    = prepare_fixture(:erb)
-        app     = Hyperloop::Application.new(root)
-        request = Rack::MockRequest.new(app)
+        root = prepare_fixture(:erb)
+        app  = Hyperloop::Application.new(root)
 
         # On the first request, <title> text should be "ERB"
-        response = request.get("/")
+        response = mock_request(app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "title")).to eql("ERB")
 
@@ -328,7 +319,7 @@ describe Hyperloop::Application do
         )
 
         # On the second request, <title> text should still be "ERB"
-        response = request.get("/")
+        response = mock_request(app).get("/")
         expect(response).to be_ok
         expect(text_in(response.body, "title")).to eql("ERB")
       end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -196,6 +196,24 @@ describe Hyperloop::Application do
       @request = Rack::MockRequest.new(@app)
     end
 
+    it "reloads layouts when they're changed" do
+      # On the first request, <title> text should not be "Changed"
+      response = @request.get("/")
+      expect(response).to be_ok
+      expect(text_in(response.body, "title")).not_to eql("Changed")
+
+      # Load layout and change the title to "Changed"
+      layout_path = File.join(@root, "app", "views", "layouts", "application.html.erb")
+      layout_data = File.read(layout_path)
+      layout_data.sub!(/<title>[^<]*<\/title>/, "<title>Changed</title>")
+      File.write(layout_path, layout_data)
+
+      # On the second request, <title> text should be "Changed"
+      response = @request.get("/")
+      expect(response).to be_ok
+      expect(text_in(response.body, "title")).to eql("Changed")
+    end
+
     it "reloads views when they're changed" do
       # On the first request, <h2> text should not be "Changed"
       response = @request.get("/")

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -276,30 +276,6 @@ describe Hyperloop::Application do
         reset_rack_env
       end
 
-      it "doesn't reload changed assets" do
-        root = prepare_fixture(:assets)
-        app  = Hyperloop::Application.new(root)
-
-        # On the first request, stylesheet should have `display: block` and not
-        # `display: inline`.
-        response = mock_request(app).get("/assets/stylesheets/app.css")
-        expect(response).to be_ok
-        expect(response.body).to match(/display: ?block/)
-        expect(response.body).not_to match(/display: ?inline/)
-
-        change_fixture(root, "app/assets/stylesheets/my-styles.scss",
-          :pattern     => "display: block",
-          :replacement => "display: inline"
-        )
-
-        # On the second request, stylesheet should still have `display: block`
-        # and not `display: inline`.
-        response = mock_request(app).get("/assets/stylesheets/app.css")
-        expect(response).to be_ok
-        expect(response.body).to match(/display: ?block/)
-        expect(response.body).not_to match(/display: ?inline/)
-      end
-
       it "doesn't reload changed views" do
         root = prepare_fixture(:erb)
         app  = Hyperloop::Application.new(root)

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -188,4 +188,30 @@ describe Hyperloop::Application do
       expect(response).to be_not_found
     end
   end
+
+  describe "live reloading" do
+    before :each do
+      @root    = prepare_fixture(:erb)
+      @app     = Hyperloop::Application.new(@root)
+      @request = Rack::MockRequest.new(@app)
+    end
+
+    it "reloads views when they're changed" do
+      # On the first request, title should be "ERB"
+      response = @request.get("/")
+      expect(response).to be_ok
+      expect(text_in(response.body, "title")).to eql("ERB")
+
+      # Load index.html.erb and change the title to "Changed"
+      index_file_path = File.join(@root, "app", "views", "index.html.erb")
+      index_file_data = File.read(index_file_path)
+      index_file_data.sub!("<title>ERB</title>", "<title>Changed</title>")
+      File.write(index_file_path, index_file_data)
+
+      # On the second request, title should be "Changed"
+      response = @request.get("/")
+      expect(response).to be_ok
+      expect(text_in(response.body, "title")).to eql("Changed")
+    end
+  end
 end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -205,11 +205,10 @@ describe Hyperloop::Application do
         expect(response.body).to match(/display: ?block/)
         expect(response.body).not_to match(/display: ?inline/)
 
-        # Load layout and change the title to "Changed"
-        asset_path = File.join(@root, "app", "assets", "stylesheets", "my-styles.scss")
-        asset_data = File.read(asset_path)
-        asset_data.sub!("display: block", "display: inline")
-        File.write(asset_path, asset_data)
+        change_fixture(@root, "app/assets/stylesheets/my-styles.scss",
+          :pattern     => "display: block",
+          :replacement => "display: inline"
+        )
 
         # On the second request, stylesheet should have `display: inline` and not
         # `display: block`.
@@ -233,11 +232,10 @@ describe Hyperloop::Application do
         expect(response).to be_ok
         expect(text_in(response.body, "title")).not_to eql("Changed")
 
-        # Load layout and change the title to "Changed"
-        layout_path = File.join(@root, "app", "views", "layouts", "application.html.erb")
-        layout_data = File.read(layout_path)
-        layout_data.sub!(/<title>[^<]*<\/title>/, "<title>Changed</title>")
-        File.write(layout_path, layout_data)
+        change_fixture(@root, "app/views/layouts/application.html.erb",
+          :pattern     => /<title>[^<]*<\/title>/,
+          :replacement => "<title>Changed</title>"
+        )
 
         # On the second request, <title> text should be "Changed"
         response = @request.get("/")
@@ -251,11 +249,10 @@ describe Hyperloop::Application do
         expect(response).to be_ok
         expect(text_in(response.body, "p.spec-in-partial")).not_to eql("Changed")
 
-        # Load partial and change the <p> to "Changed"
-        partial_path = File.join(@root, "app", "views", "subdir", "_partial.html.erb")
-        partial_data = File.read(partial_path)
-        partial_data.sub!(/<p class="spec-in-partial">[^<]*<\/p>/, "<p class=\"spec-in-partial\">Changed</p>")
-        File.write(partial_path, partial_data)
+        change_fixture(@root, "app/views/subdir/_partial.html.erb",
+          :pattern     => /<p class="spec-in-partial">[^<]*<\/p>/,
+          :replacement => "<p class=\"spec-in-partial\">Changed</p>"
+        )
 
         # On the second request, <p> text should be "Changed"
         response = @request.get("/")
@@ -269,11 +266,10 @@ describe Hyperloop::Application do
         expect(response).to be_ok
         expect(text_in(response.body, "h2")).not_to eql("Changed")
 
-        # Load index.html.erb and change the title to "Changed"
-        index_file_path = File.join(@root, "app", "views", "index.html.erb")
-        index_file_data = File.read(index_file_path)
-        index_file_data.sub!(/<h2>[^<]*<\/h2>/, "<h2>Changed</h2>")
-        File.write(index_file_path, index_file_data)
+        change_fixture(@root, "app/views/index.html.erb",
+          :pattern     => /<h2>[^<]*<\/h2>/,
+          :replacement => "<h2>Changed</h2>"
+        )
 
         # On the second request, <h2> text should be "Changed"
         response = @request.get("/")
@@ -303,11 +299,10 @@ describe Hyperloop::Application do
         expect(response.body).to match(/display: ?block/)
         expect(response.body).not_to match(/display: ?inline/)
 
-        # Load layout and change the title to "Changed"
-        asset_path = File.join(root, "app", "assets", "stylesheets", "my-styles.scss")
-        asset_data = File.read(asset_path)
-        asset_data.sub!("display: block", "display: inline")
-        File.write(asset_path, asset_data)
+        change_fixture(root, "app/assets/stylesheets/my-styles.scss",
+          :pattern     => "display: block",
+          :replacement => "display: inline"
+        )
 
         # On the second request, stylesheet should still have `display: inline`
         # and not `display: block`.
@@ -327,11 +322,10 @@ describe Hyperloop::Application do
         expect(response).to be_ok
         expect(text_in(response.body, "title")).to eql("ERB")
 
-        # Load index.html.erb and change the title to "Changed"
-        index_file_path = File.join(root, "app", "views", "index.html.erb")
-        index_file_data = File.read(index_file_path)
-        index_file_data.sub!("<title>ERB</title>", "<title>Changed</title>")
-        File.write(index_file_path, index_file_data)
+        change_fixture(root, "app/views/index.html.erb",
+          :pattern     => "<title>ERB</title>",
+          :replacement => "<title>Changed</title>"
+        )
 
         # On the second request, <title> text should still be "ERB"
         response = request.get("/")

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -191,27 +191,27 @@ describe Hyperloop::Application do
 
   describe "live reloading" do
     before :each do
-      @root    = prepare_fixture(:erb)
+      @root    = prepare_fixture(:assets)
       @app     = Hyperloop::Application.new(@root)
       @request = Rack::MockRequest.new(@app)
     end
 
     it "reloads views when they're changed" do
-      # On the first request, title should be "ERB"
+      # On the first request, <h2> text should not be "Changed"
       response = @request.get("/")
       expect(response).to be_ok
-      expect(text_in(response.body, "title")).to eql("ERB")
+      expect(text_in(response.body, "h2")).not_to eql("Changed")
 
       # Load index.html.erb and change the title to "Changed"
       index_file_path = File.join(@root, "app", "views", "index.html.erb")
       index_file_data = File.read(index_file_path)
-      index_file_data.sub!("<title>ERB</title>", "<title>Changed</title>")
+      index_file_data.sub!(/<h2>[^<]*<\/h2>/, "<h2>Changed</h2>")
       File.write(index_file_path, index_file_data)
 
-      # On the second request, title should be "Changed"
+      # On the second request, <h2> text should be "Changed"
       response = @request.get("/")
       expect(response).to be_ok
-      expect(text_in(response.body, "title")).to eql("Changed")
+      expect(text_in(response.body, "h2")).to eql("Changed")
     end
   end
 end

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -198,25 +198,25 @@ describe Hyperloop::Application do
       end
 
       it "reloads changed assets" do
-        # On the first request, stylesheet should have `display: block;` and not
-        # `display: inline;`.
+        # On the first request, stylesheet should have `display: block` and not
+        # `display: inline`.
         response = @request.get("/assets/stylesheets/app.css")
         expect(response).to be_ok
-        expect(response.body).to match(/display: ?block;/)
-        expect(response.body).not_to match(/display: ?inline;/)
+        expect(response.body).to match(/display: ?block/)
+        expect(response.body).not_to match(/display: ?inline/)
 
         # Load layout and change the title to "Changed"
         asset_path = File.join(@root, "app", "assets", "stylesheets", "my-styles.scss")
         asset_data = File.read(asset_path)
-        asset_data.sub!("display: block;", "display: inline;")
+        asset_data.sub!("display: block", "display: inline")
         File.write(asset_path, asset_data)
 
-        # On the second request, stylesheet should have `display: inline;` and not
-        # `display: block;`.
+        # On the second request, stylesheet should have `display: inline` and not
+        # `display: block`.
         response = @request.get("/assets/stylesheets/app.css")
         expect(response).to be_ok
-        expect(response.body).to match(/display: ?inline;/)
-        expect(response.body).not_to match(/display: ?block;/)
+        expect(response.body).to match(/display: ?inline/)
+        expect(response.body).not_to match(/display: ?block/)
       end
     end
 

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -196,6 +196,28 @@ describe Hyperloop::Application do
       @request = Rack::MockRequest.new(@app)
     end
 
+    it "reloads assets when they're changed" do
+      # On the first request, stylesheet should have `display: block;` and not
+      # `display: inline;`.
+      response = @request.get("/assets/stylesheets/app.css")
+      expect(response).to be_ok
+      expect(response.body).to match(/display: ?block;/)
+      expect(response.body).not_to match(/display: ?inline;/)
+
+      # Load layout and change the title to "Changed"
+      asset_path = File.join(@root, "app", "assets", "stylesheets", "my-styles.scss")
+      asset_data = File.read(asset_path)
+      asset_data.sub!("display: block;", "display: inline;")
+      File.write(asset_path, asset_data)
+
+      # On the second request, stylesheet should have `display: inline;` and not
+      # `display: block;`.
+      response = @request.get("/assets/stylesheets/app.css")
+      expect(response).to be_ok
+      expect(response.body).to match(/display: ?inline;/)
+      expect(response.body).not_to match(/display: ?block;/)
+    end
+
     it "reloads layouts when they're changed" do
       # On the first request, <title> text should not be "Changed"
       response = @request.get("/")

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -245,6 +245,24 @@ describe Hyperloop::Application do
         expect(text_in(response.body, "title")).to eql("Changed")
       end
 
+      it "reloads changed partials" do
+        # On the first request, <p> text should not be "Changed"
+        response = @request.get("/")
+        expect(response).to be_ok
+        expect(text_in(response.body, "p.spec-in-partial")).not_to eql("Changed")
+
+        # Load partial and change the <p> to "Changed"
+        partial_path = File.join(@root, "app", "views", "subdir", "_partial.html.erb")
+        partial_data = File.read(partial_path)
+        partial_data.sub!(/<p class="spec-in-partial">[^<]*<\/p>/, "<p class=\"spec-in-partial\">Changed</p>")
+        File.write(partial_path, partial_data)
+
+        # On the second request, <p> text should be "Changed"
+        response = @request.get("/")
+        expect(response).to be_ok
+        expect(text_in(response.body, "p.spec-in-partial")).to eql("Changed")
+      end
+
       it "reloads changed views" do
         # On the first request, <h2> text should not be "Changed"
         response = @request.get("/")

--- a/spec/application_spec.rb
+++ b/spec/application_spec.rb
@@ -304,8 +304,8 @@ describe Hyperloop::Application do
           :replacement => "display: inline"
         )
 
-        # On the second request, stylesheet should still have `display: inline`
-        # and not `display: block`.
+        # On the second request, stylesheet should still have `display: block`
+        # and not `display: inline`.
         response = request.get("/assets/stylesheets/app.css")
         expect(response).to be_ok
         expect(response.body).to match(/display: ?block/)

--- a/spec/fixtures/partials/app/views/subdir/_partial.html.erb
+++ b/spec/fixtures/partials/app/views/subdir/_partial.html.erb
@@ -1,1 +1,1 @@
-<p>This is coming from a partial.</p>
+<p class="spec-in-partial">This is coming from a partial.</p>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,14 @@ require "pry"
 require "hyperloop"
 
 module Helpers
+  # Public: Clean up all prepared fixtures.
+  #
+  # Returns nothing.
+  def cleanup_fixtures
+    tmp_fixtures_dir = File.join("tmp", "spec", "fixtures")
+    FileUtils.rm_rf(tmp_fixtures_dir)
+  end
+
   def html(str)
     Nokogiri::HTML(str)
   end
@@ -13,6 +21,25 @@ module Helpers
       :find_partial_view  => nil,
       :find_template_view => nil
     )
+  end
+
+  # Public: Prepare a fixture with the specified name.
+  #
+  # name - Symbol name of the fixture to prepare. The name passed here will be
+  #        looked up in the spec/fixtures directory.
+  #
+  # Returns a string filepath representing the new location of the prepared
+  # fixture.
+  def prepare_fixture(name)
+    root     = File.join("spec", "fixtures", name.to_s)
+    contents = File.join(root, ".")
+    tmp_root = File.join("tmp", root)
+
+    # Create the tmp/spec/fixtures/:name directory and copy the fixture into it.
+    FileUtils.mkdir_p(tmp_root)
+    FileUtils.cp_r(contents, tmp_root)
+
+    tmp_root
   end
 
   def text_in(html_str, selector)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,7 +79,9 @@ module Helpers
     contents = File.join(root, ".")
     tmp_root = File.join("tmp", root)
 
-    # Create the tmp/spec/fixtures/:name directory and copy the fixture into it.
+    # Delete and recreate the tmp/spec/fixtures/:name directory, then copy the
+    # fixture into it.
+    FileUtils.rm_rf(tmp_root)
     FileUtils.mkdir_p(tmp_root)
     FileUtils.cp_r(contents, tmp_root)
 
@@ -119,8 +121,8 @@ module Helpers
     @mock_app ||= double("rack app", :call => Hyperloop::Response.new.finish )
   end
 
-  def mock_request
-    Rack::MockRequest.new(mock_app)
+  def mock_request(app = nil)
+    Rack::MockRequest.new(app || mock_app)
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,30 @@ module Helpers
     tmp_root
   end
 
+  # Public: Set the RACK_ENV environment variable back to whatever it was when
+  # the spec started running. If RACK_ENV wasn't set before the spec started
+  # running, it will be deleted.
+  #
+  # Returns nothing.
+  def reset_rack_env
+    if defined?(@old_rack_env)
+      ENV["RACK_ENV"] = @old_rack_env
+    else
+      ENV.delete("RACK_ENV")
+    end
+  end
+
+  # Public: Set the RACK_ENV environment variable to the specified value.
+  #
+  # name - Symbol environment name to set RACK_ENV to. Should be :development,
+  #        :test, or :production.
+  #
+  # Returns nothing.
+  def set_rack_env(name)
+    @old_rack_env = ENV["RACK_ENV"] if ENV.key?("RACK_ENV")
+    ENV["RACK_ENV"] = name.to_s
+  end
+
   def text_in(html_str, selector)
     node = html(html_str).at_css(selector)
     node && node.text

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,18 @@ module Helpers
   #                :replacement - (Required) String to replace the found pattern
   #                               with.
   #
+  # Examples:
+  #
+  #   change_fixture("tmp/spec/fixtures/erb", "app/views/index.html.erb",
+  #     :pattern     => "<title>ERB</title>",
+  #     :replacement => "<title>Changed</title>"
+  #   )
+  #
+  #   change_fixture("tmp/spec/fixtures/erb", "app/views/index.html.erb",
+  #     :pattern     => /<title>[^<]*<\/title>/,
+  #     :replacement => "<title>Changed</title>"
+  #   )
+  #
   # Returns nothing.
   def change_fixture(fixture_path, file_path, options = {})
     pattern     = options[:pattern]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,11 @@ module Helpers
     raise ArgumentError, "change_fixture must include a :pattern option" unless pattern
     raise ArgumentError, "change_fixture must include a :replacement option" unless replacement
 
-    full_file_path = File.join(fixture_path, file_path)
-    data           = File.read(full_file_path).sub(pattern, replacement)
-    File.write(full_file_path, data)
+    File.open(File.join(fixture_path, file_path), "r+") do |f|
+      data = f.read.sub(pattern, replacement)
+      f.rewind
+      f.write(data)
+    end
   end
 
   def html(str)
@@ -126,6 +128,12 @@ module Helpers
   end
 end
 
+ENV["RACK_ENV"] ||= "test"
+
 RSpec.configure do |c|
   c.include(Helpers)
+
+  c.after :all do
+    cleanup_fixtures
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,13 @@ module Helpers
   # name - Symbol name of the fixture to prepare. The name passed here will be
   #        looked up in the spec/fixtures directory.
   #
+  # Note:
+  #
+  #   This method exists along with change_fixture and cleanup_fixtures. If
+  #   these get used a lot more or more fixture-related functionality is added,
+  #   it may make sense to extract a Fixture class and move these methods into
+  #   it.
+  #
   # Returns a string filepath representing the new location of the prepared
   # fixture.
   def prepare_fixture(name)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,31 @@ module Helpers
     FileUtils.rm_rf(tmp_fixtures_dir)
   end
 
+  # Public: Change the contents of a file in a fixture.
+  #
+  # fixture_path - Path to the fixture containing the file we want to change.
+  # file_path    - Path (relative to fixture_path) of the file we want to
+  #                change.
+  # options      - Hash containing the following keys:
+  #                :pattern     - (Required) Regexp or String to find in the
+  #                               file. Only the first occurrence will be
+  #                               matched.
+  #                :replacement - (Required) String to replace the found pattern
+  #                               with.
+  #
+  # Returns nothing.
+  def change_fixture(fixture_path, file_path, options = {})
+    pattern     = options[:pattern]
+    replacement = options[:replacement]
+
+    raise ArgumentError, "change_fixture must include a :pattern option" unless pattern
+    raise ArgumentError, "change_fixture must include a :replacement option" unless replacement
+
+    full_file_path = File.join(fixture_path, file_path)
+    data           = File.read(full_file_path).sub(pattern, replacement)
+    File.write(full_file_path, data)
+  end
+
   def html(str)
     Nokogiri::HTML(str)
   end

--- a/spec/view/scope_spec.rb
+++ b/spec/view/scope_spec.rb
@@ -1,7 +1,7 @@
 describe Hyperloop::View::Scope do
   before :each do
     view_registry = Hyperloop::View::Registry.new("spec/fixtures/partials/")
-    @request      = Rack::MockRequest.new(mock_app)
+    @request      = mock_request
     @scope        = Hyperloop::View::Scope.new(@request, view_registry)
   end
 


### PR DESCRIPTION
This branch adds live reloading when `RACK_ENV != "production"`, as requested in #14.

The bulk of this pull involves tweaking the fixture setup. Instead of reading a fixture directly from `spec/fixtures/:name`, the fixture is copied to `tmp/spec/fixtures/:name`, where it can then be freely modified without fucking up the original fixture. This way, we can do tests where we change the fixture and make sure live-reloading works as expected.

<del>Note: there's a weird intermittent bug in the tests. Something like 10% of the time, live reloading will work for assets when in production, even though it shouldn't. I gotta talk to someone who knows more about Sprockets; I'm pretty sure Sprockets is doing its own live-reloading in production, and I need to figure out how to turn it off. That can be done in a separate PR though.</del>


For now, live reloading of assets may still happen in production. As far as I can tell, there's no way to turn it off in Sprockets, and turning it off is just an optimization, so let's leave it on until we decide that asset requests are too slow.

/cc @fabianperez @jessicard 
